### PR TITLE
feat: add readme generator

### DIFF
--- a/util/languages.json
+++ b/util/languages.json
@@ -1,0 +1,32 @@
+{
+  "languages": [
+    {
+      "name": "Python",
+      "code": "py",
+      "localEnvironment": "Python >= 3.7",
+      "dependencies": "pip install -r requirements.txt",
+      "command": "python simple.py"
+    },
+    {
+      "name": "Ruby",
+      "code": "rb",
+      "localEnvironment": "Ruby >= 2.6, bundler",
+      "dependencies": "bundle install",
+      "command": "ruby simple.rb"
+    },
+    {
+      "name": "Go",
+      "code": "go",
+      "localEnvironment": "Go >= 1.8",
+      "dependencies": "go get github.com/algolia/algoliasearch-client-go/v3@v3.Y.Z",
+      "command": "go run simple.go"
+    },
+    {
+      "name": "PHP",
+      "code": "php",
+      "localEnvironment": "PHP >= 7.2, [Composer](https://getcomposer.org/doc/00-intro.md)",
+      "dependencies": "php composer.phar install",
+      "command": "php simle.php"
+    }
+  ]
+}

--- a/util/languages.json
+++ b/util/languages.json
@@ -27,6 +27,22 @@
       "localEnvironment": "PHP >= 7.2, [Composer](https://getcomposer.org/doc/00-intro.md)",
       "dependencies": "php composer.phar install",
       "command": "php simle.php"
+    },
+    {
+      "name": ".NET",
+      "code": "cs",
+      "localEnvironment": ".NET Standard 1.3-2.1 or .NET Core 1.0-3.0 or .NET Framework 4.5-4.7.1",
+      "dependencies": "...",
+      "command": "dotnet run simple",
+      "readmeDirectory": "dotnet"
+    },
+    {
+      "name": "JavaScript",
+      "code": "js",
+      "localEnvironment": "Node.js",
+      "dependencies": "npm install",
+      "command": "node simple.js",
+      "readmeDirectory": "js"
     }
   ]
 }

--- a/util/quickstart.template
+++ b/util/quickstart.template
@@ -1,0 +1,48 @@
+# Get started with the Algolia API client in: $language
+
+This quickstart demonstrates various use cases of the [Algolia $language API Client](https://www.algolia.com/doc/api-client/getting-started/install/$languageLowerCase/?client=$languageLowerCase).
+
+## Set up the quickstart
+
+You can either set up a local environment, or use Docker.
+If you're using Docker, consider using Visual Studio Code with the
+[Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+extension, which allows you to run the quickstarts from VSCode _inside_ docker
+containers.
+
+### Prerequisites
+
+- An Algolia account. If you don't have one, [create an account for free](https://www.algolia.com/users/sign_up)
+- A local environment: $localEnvironment or [Docker](https://www.docker.com/get-started)
+- If you're using a local environment and not Docker, you need to install the dependencies manually: `$dependencies`.
+
+<details>
+  <summary>Using Visual Studio Code</summary>
+
+VScode with the [Remote - Containers](https://code.visualstudio.com/docs/remote/containers) extension allows you to run any quickstart by using the command [**Remote-Containers: Open Folder in Container**](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-an-existing-folder-in-a-container) command.
+Every quickstart contains a [`.devcontainer.json`](./.devcontainer/devcontainer.json) and a [`Dockerfile`](./.devcontainer/Dockerfile).
+
+</details>
+
+### Set up Algolia
+
+1. [Create an Algolia application](https://www.algolia.com/account/plan/create?from=dashboard) and an [Algolia index](https://www.algolia.com/doc/guides/getting-started/quick-start/tutorials/getting-started-with-the-dashboard/#indices)
+2. Copy the file [`.env.example`](.env.example) and rename it to `.env`
+3. Set the environment variables `ALGOLIA_APP_ID`, `ALGOLIA_API_KEY` and `ALGOLIA_INDEX_NAME` in the `.env` file. You can obtain those from the [Algolia Dashboard](https://www.algolia.com/api-keys/). The `ALGOLIA_API_KEY` should be the "Admin API Key", which is necessary for indexing.
+
+## How to use
+
+You can run each script in this folder using the $language command line.
+
+**Example**: to run the `simple.$code` sample:
+
+```bash
+$command
+```
+
+## Available quickstarts
+
+| File                               | Description                                  |
+| ---------------------------------- | -------------------------------------------- |
+| [simple.$code](./simple.$code)     | Index a single object and run a search query |
+| [indexing.$code](./indexing.$code) | Showcase the main indexing methods           |

--- a/util/readmes.py
+++ b/util/readmes.py
@@ -1,0 +1,90 @@
+"""
+Create README files for every language from a common template.
+
+To add a new language:
+
+    - add an entry to the `languages.json` file, for example:
+
+    ```json
+    {
+        "language": // the name of the language,
+        "code": // the common file extension,
+        "localEnvironment": // any requirements for running the quickstarts locally, for example a programming language, or a package manager,
+        "dependencies": // the command to install the dependencies,
+        "command": // the command to run the `simple` example
+    }
+    ```
+"""
+
+import json
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from string import Template
+from typing import Dict
+
+
+def cli() -> Namespace:
+    """Define command-line interface.
+
+    Running the script generates **ALL** README files.
+    """
+    p = ArgumentParser(
+        description="Generate READMEs for Algolia's API client quickstarts."
+    )
+
+    # the language definition file (for possible override)
+    p.add_argument(
+        "-l",
+        "--languages",
+        default="languages.json",
+        type=open,
+        help="A file with the language definitions.",
+    )
+
+    # which template to use
+    p.add_argument(
+        "-t",
+        "--template",
+        default="quickstart.template",
+        type=open,
+        help="A template file for the READMEs.",
+    )
+
+    return p.parse_args()
+
+
+def render(template: Template, data: Dict[str, str]) -> str:
+    """Render a tamples"""
+    return template.substitute(**data)
+
+
+if __name__ == "__main__":
+
+    # Get command-line options
+    args = cli()
+
+    # Read the template file
+    template = Template(args.template.read())
+
+    # Read the data file
+    languages_data = json.loads(args.languages.read())
+
+    for lang in languages_data["languages"]:
+
+        # Prepare the data to render into the template
+        data = {
+            "language": lang["name"],
+            "code": lang["code"],
+            "languageLowerCase": lang["name"].lower(),
+            "localEnvironment": lang["localEnvironment"],
+            "dependencies": lang["dependencies"],
+            "command": lang["command"],
+        }
+
+        # Get the rendered README as string
+        readme = render(template, data)
+
+        # write files to disk
+        out_file_path = Path("..") / lang["name"].lower() / "README.md"
+        with open(out_file_path, "w") as out_f:
+            out_f.write(readme)

--- a/util/readmes.py
+++ b/util/readmes.py
@@ -17,10 +17,12 @@ To add a new language:
 """
 
 import json
+import logging
 from argparse import ArgumentParser, Namespace
-from pathlib import Path
 from string import Template
 from typing import Dict
+
+log = logging.getLogger(__name__)
 
 
 def cli() -> Namespace:
@@ -85,6 +87,14 @@ if __name__ == "__main__":
         readme = render(template, data)
 
         # write files to disk
-        out_file_path = Path("..") / lang["name"].lower() / "README.md"
-        with open(out_file_path, "w") as out_f:
-            out_f.write(readme)
+        readme_dir = lang.get("readmeDirectory") or lang["name"].lower()
+
+        try:
+            with open(f"../{readme_dir}/README.md", "w") as out_f:
+                out_f.write(readme)
+        except FileNotFoundError:
+            print(
+                f"No such directory: `{readme_dir}`. Ignoring. "
+                f"Check, if your file `{args.languages.name}` is up-to-date."
+            )
+            continue


### PR DESCRIPTION
<!-- Describe your Pull Request -->

This PR adds a folder `util` to the repo which generates README files from a common template.

The template for the quickstart is in `quickstart.template`. The language data is in `languages.json`.
Run the script `python readmes.py` to generate all READMEs for the API clients.

**Contributing to Algolia Samples**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.