### PR TITLE
feat generate search only rate limit api key

### DIFF
--- a/ruby/generate_key.rb
+++ b/ruby/generate_key.rb
@@ -1,0 +1,39 @@
+# API Key Generator
+# This script will generate an API key for an Algolia application.
+# The generated key will be valid for Search operations, and will be limited to 100 queries per hour.
+
+require 'dotenv/load'
+require 'algolia'
+
+# Algolia client credentials
+ALGOLIA_APP_ID = ENV['ALGOLIA_APP_ID']
+ALGOLIA_API_KEY = ENV['ALGOLIA_API_KEY']
+ALGOLIA_INDEX_NAME = ENV['ALGOLIA_INDEX_NAME']
+
+# Initialize the client
+# https://www.algolia.com/doc/api-client/getting-started/initialize/ruby/?client=ruby#initialize-the-search-client
+client = Algolia::Search::Client.create(ALGOLIA_APP_ID, ALGOLIA_API_KEY)
+
+# Initialize an index
+# https://www.algolia.com/doc/api-client/getting-started/instantiate-client-index/#initialize-an-index
+index = client.init_index(ALGOLIA_INDEX_NAME)
+
+# Set permissions for API key
+# https://www.algolia.com/doc/api-reference/api-methods/add-api-key/?client=ruby#method-param-acl
+acl = ['search']
+
+# Set the rate limited parameters for API key
+# https://www.algolia.com/doc/api-reference/api-methods/add-api-key/#method-param-maxqueriesperipperhour
+
+opts = {
+    description: "TEST !! Restricted search-only API key",
+    # Rate-limit to 100 requests per hour per IP address
+    maxQueriesPerIPPerHour: 100
+    }
+
+# Create a new restricted search-only API key
+puts "Creating key new restricted search-only API key ..."
+
+res = client.add_api_key(acl, opts)
+
+puts "You can check your Dashboard now ! "

--- a/ruby/generate_key.rb
+++ b/ruby/generate_key.rb
@@ -10,12 +10,9 @@ ALGOLIA_APP_ID = ENV['ALGOLIA_APP_ID']
 ALGOLIA_API_KEY = ENV['ALGOLIA_API_KEY']
 ALGOLIA_INDEX_NAME = ENV['ALGOLIA_INDEX_NAME']
 
-# Initialize the client
+# Initialize the client and the index
 # https://www.algolia.com/doc/api-client/getting-started/initialize/ruby/?client=ruby#initialize-the-search-client
 client = Algolia::Search::Client.create(ALGOLIA_APP_ID, ALGOLIA_API_KEY)
-
-# Initialize an index
-# https://www.algolia.com/doc/api-client/getting-started/instantiate-client-index/#initialize-an-index
 index = client.init_index(ALGOLIA_INDEX_NAME)
 
 # Set permissions for API key
@@ -26,14 +23,16 @@ acl = ['search']
 # https://www.algolia.com/doc/api-reference/api-methods/add-api-key/#method-param-maxqueriesperipperhour
 
 opts = {
-    description: "TEST !! Restricted search-only API key",
+    description: "Restricted search-only API key limited to 100 API calls per hour",
     # Rate-limit to 100 requests per hour per IP address
     maxQueriesPerIPPerHour: 100
     }
 
 # Create a new restricted search-only API key
-puts "Creating key new restricted search-only API key ..."
+puts "Creating new restricted search-only API key ..."
 
 res = client.add_api_key(acl, opts)
 
-puts "You can check your Dashboard now ! "
+# Print the new generated search api key
+new_search_api_key = res.raw_response[:key]
+puts "Your new key has been generated successfully : #{new_search_api_key}"


### PR DESCRIPTION
This script is generating a search only rate limited api key in ruby
When running the script, once the API KEY is generated user will be prompted to check the dashboard.
I am not able to access the response with 
`puts key = res["key"]`

Able to access the key but sure there is a more straight forward way ... 
```     
created_at_timestamp = Time.now.to_i
res = client.add_api_key(acl, opts)
puts "Check your Dashboard now ! :-)" 

sleep(30)
# Lists API Keys
all_api_keys= client.list_api_keys
all_api_keys[:keys].each do |key|
    if key[:description] == opts[:description] && key[:createdAt] >= created_at_timestamp
        puts "---------"
        puts "key generated successfully - new api key => #{key[:value]} "
        puts "---------"
   end
end
```
**Contributing to Algolia Samples**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x ] I acknowledge that all my contributions will be made under the project's license.