### PR TITLE
fix: update broken link

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -1,6 +1,6 @@
 # API Clients Quickstarts: Go
 
-This quickstart demonstrates various usages of the the [Algolia Go API Client](https://www.algolia.com/doc/api-client/getting-started/install/python/?client=go).
+This quickstart demonstrates various usages of the the [Algolia Go API Client](https://www.algolia.com/doc/api-client/getting-started/install/go/?client=go).
 
 ## Setting up the quickstart
 


### PR DESCRIPTION
Updated link on Go readme that was pointing to the docs for the python client.

**Contributing to Algolia Samples**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.