### PR TITLE
feat: backup and restore scripts for python client

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -36,3 +36,6 @@ python simple.py
 | ------------- | ------------- |
 | [simple.py](./simple.py)  | Index a single object and run a search query |
 | [indexing.py](./indexing.py)  | Showcase of the main indexing methods |
+| [generate_key.py](./generate_key.py)  | Generate a rate limited API key |
+| [backup.py](./backup.py)  | Backup an index and associated rules, synonyms and settings |
+| [restore.py](./restore.py)  | Restore an index from a local file |

--- a/python/backup.py
+++ b/python/backup.py
@@ -1,0 +1,81 @@
+"""
+Backup Index
+
+This script will export an index, including any settings, rules and synonyms.
+
+It can be used in conjunction with restore.py to backup and restore an index to an application.
+
+"""
+
+import json
+from os import getenv
+
+# Install the API client: https://www.algolia.com/doc/api-client/getting-started/install/python/?client=python
+from algoliasearch.search_client import SearchClient
+from dotenv import find_dotenv, load_dotenv
+
+load_dotenv(find_dotenv())
+
+# Get your Algolia Application ID and (admin) API key from the dashboard: https://www.algolia.com/account/api-keys
+# and choose a name for your index. Add these environment variables to a `.env` file:
+ALGOLIA_APP_ID = getenv('ALGOLIA_APP_ID')
+ALGOLIA_API_KEY = getenv('ALGOLIA_API_KEY')
+ALGOLIA_INDEX_NAME = getenv('ALGOLIA_INDEX_NAME')
+
+# Start the API client
+# https://www.algolia.com/doc/api-client/getting-started/instantiate-client-index/
+client = SearchClient.create(ALGOLIA_APP_ID, ALGOLIA_API_KEY)
+
+# Create an index (or connect to it, if an index with the name `ALGOLIA_INDEX_NAME` already exists)
+# https://www.algolia.com/doc/api-client/getting-started/instantiate-client-index/#initialize-an-index
+index = client.init_index(ALGOLIA_INDEX_NAME)
+
+# Initialise lists to store the exported data
+records, settings, rules, synonyms = [], [], [], []
+
+# Get the index records and any associated rules, settings, and synonyms.
+try:
+    # Get all the records from the index and store them in a list
+    print('Retrieving records...')
+    records = list(index.browse_objects())
+    print(f'{len(records)} records retrieved.')
+
+    # Get the settings for the index
+    print('Retrieving settings...')
+    settings = index.get_settings()
+    print('Settings retrieved.')
+
+    # Get the rules for the index
+    print('Retrieving rules...')
+    rules = list(index.browse_rules())
+    print(f'{str(len(rules))} rules retrieved.')
+
+    # Get the synonyms for the index
+    print('Retrieving synonyms...')
+    synonyms = list(index.browse_synonyms())
+    print(f'{str(len(synonyms))} synonyms retrieved.')
+except Exception as e:
+    print(f'Error retrieving data: {e}')
+    exit()
+
+# Create a function to help with writing the output data
+def create_json(data, name):
+    '''
+    Converts a list to a json file
+    '''
+    if data:
+        json_data = json.dumps(list)
+        with open(f'{ALGOLIA_INDEX_NAME}_{name}.json', 'w', encoding='utf-16') as file:
+            file.write(json_data)
+
+# Write the exported data to output files
+print('Exporting data...')
+try:
+    create_json(records, 'index')
+    create_json(settings, 'settings')
+    create_json(rules, 'rules')
+    create_json(synonyms, 'synonyms')
+    print('Data exported successfully.')
+except Exception as e:
+    print(f'Error exporting data: {e}')
+    exit()

--- a/python/backup.py
+++ b/python/backup.py
@@ -64,7 +64,7 @@ def create_json(data, name):
     Converts a list to a json file
     '''
     if data:
-        json_data = json.dumps(list)
+        json_data = json.dumps(data)
         with open(f'{ALGOLIA_INDEX_NAME}_{name}.json', 'w', encoding='utf-16') as file:
             file.write(json_data)
 
@@ -72,9 +72,13 @@ def create_json(data, name):
 print('Exporting data...')
 try:
     create_json(records, 'index')
+    print('Exported index.')
     create_json(settings, 'settings')
+    print('Exported settings.')
     create_json(rules, 'rules')
+    print('Exported rules.')
     create_json(synonyms, 'synonyms')
+    print('Exported synonyms.')
     print('Data exported successfully.')
 except Exception as e:
     print(f'Error exporting data: {e}')

--- a/python/backup.py
+++ b/python/backup.py
@@ -8,6 +8,7 @@ It can be used in conjunction with restore.py to backup and restore an index to 
 """
 
 import json
+import os.path
 from os import getenv
 
 # Install the API client: https://www.algolia.com/doc/api-client/getting-started/install/python/?client=python
@@ -21,6 +22,9 @@ load_dotenv(find_dotenv())
 ALGOLIA_APP_ID = getenv('ALGOLIA_APP_ID')
 ALGOLIA_API_KEY = getenv('ALGOLIA_API_KEY')
 ALGOLIA_INDEX_NAME = getenv('ALGOLIA_INDEX_NAME')
+
+# Set the path for the current file, we'll need this when generating the exports
+current_path = os.path.dirname(os.path.abspath(__file__))
 
 # Start the API client
 # https://www.algolia.com/doc/api-client/getting-started/instantiate-client-index/
@@ -59,25 +63,25 @@ except Exception as e:
     exit()
 
 # Create a function to help with writing the output data
-def create_json(data, name):
+def create_json(data, name, path):
     '''
     Converts a list to a json file
     '''
     if data:
         json_data = json.dumps(data)
-        with open(f'{ALGOLIA_INDEX_NAME}_{name}.json', 'w', encoding='utf-16') as file:
+        with open(f'{path}/{ALGOLIA_INDEX_NAME}_{name}.json', 'w', encoding='utf-16') as file:
             file.write(json_data)
 
 # Write the exported data to output files
 print('Exporting data...')
 try:
-    create_json(records, 'index')
+    create_json(records, 'index', current_path)
     print('Exported index.')
-    create_json(settings, 'settings')
+    create_json(settings, 'settings', current_path)
     print('Exported settings.')
-    create_json(rules, 'rules')
+    create_json(rules, 'rules', current_path)
     print('Exported rules.')
-    create_json(synonyms, 'synonyms')
+    create_json(synonyms, 'synonyms', current_path)
     print('Exported synonyms.')
     print('Data exported successfully.')
 except Exception as e:

--- a/python/restore.py
+++ b/python/restore.py
@@ -1,0 +1,116 @@
+"""
+Restore Index
+
+This script will restore an index, including any settings, rules and synonyms.
+
+It can be used in conjuction with backup.py to backup and restore an index to an application.
+
+When run, the user will be prompted to enter an index name. The script will look for files prefixed
+with this index name to use for the restore. E.g. if the index name is 'my-index', the script will
+look for 'my-index_index.json', 'my-index_rules.json', 'my-index_settings.json' and 
+'my-index_synonyms.json' files in the same directory.
+
+This script will overwrite any existing indexes with the same name.
+
+"""
+
+import json
+import os.path
+from os import getenv
+
+# Install the API client: https://www.algolia.com/doc/api-client/getting-started/install/python/?client=python
+from algoliasearch.search_client import SearchClient
+from dotenv import find_dotenv, load_dotenv
+
+load_dotenv(find_dotenv())
+
+# Get your Algolia Application ID and (admin) API key from the dashboard: https://www.algolia.com/account/api-keys
+# and choose a name for your index. Add these environment variables to a `.env` file:
+ALGOLIA_APP_ID = getenv('ALGOLIA_APP_ID')
+ALGOLIA_API_KEY = getenv('ALGOLIA_API_KEY')
+ALGOLIA_INDEX_NAME = input('Enter index name: ')
+
+# Start the API client
+# https://www.algolia.com/doc/api-client/getting-started/instantiate-client-index/
+client = SearchClient.create(ALGOLIA_APP_ID, ALGOLIA_API_KEY)
+
+# Create an index (or connect to it, if an index with the name `ALGOLIA_INDEX_NAME` already exists)
+# https://www.algolia.com/doc/api-client/getting-started/instantiate-client-index/#initialize-an-index
+index = client.init_index(ALGOLIA_INDEX_NAME)
+
+# Check to see which files are available for restoration. There must be at least an index file.
+current_path = os.path.dirname(os.path.abspath(__file__))
+
+is_index_file = os.path.isfile(f'{current_path}/{ALGOLIA_INDEX_NAME}_index.json')
+is_settings_file = os.path.isfile(f'{current_path}/{ALGOLIA_INDEX_NAME}_settings.json')
+is_rules_file = os.path.isfile(f'{current_path}/{ALGOLIA_INDEX_NAME}_rules.json')
+is_synonyms_file = os.path.isfile(f'{current_path}/{ALGOLIA_INDEX_NAME}_synonyms.json')
+
+if not is_index_file:
+    print('No index file available. Terminating script.')
+    exit()
+
+# Load the json files so that the data can be restored
+with open(f'{current_path}/{ALGOLIA_INDEX_NAME}_index.json', 'r') as f:
+    index_data = json.load(f)
+
+if is_settings_file:
+    with open(f'{current_path}/{ALGOLIA_INDEX_NAME}_settings.json', 'r') as f:
+        settings_data = json.load(f)
+
+if is_rules_file:
+    with open(f'{current_path}/{ALGOLIA_INDEX_NAME}_rules.json', 'r') as f:
+        rules_data = json.load(f)
+
+if is_synonyms_file:
+    with open(f'{current_path}/{ALGOLIA_INDEX_NAME}_synonyms.json', 'r') as f:
+        synonyms_data = json.load(f)
+
+# Check the status of the current index.
+try:
+    existing_records = list(index.browse_objects(
+        {"attributesToRetrieve": ["objectId"]}
+    ))
+except Exception as e:
+    print(f'Error querying existing index {e}. Exiting')
+    exit()
+
+# Confirm with the user that they're going to overwrite an existing index
+confirmation = ''
+
+while confirmation.lower() not in ['y', 'n', 'yes', 'no']:
+    confirmation = input(f'\
+WARNING: Continuing will overwrite {str(len(existing_records))} records \
+in existing index "{ALGOLIA_INDEX_NAME}" with {str(len(index_data))} records from local index. \
+Do you want to continue (Y/N): '
+    )
+
+if confirmation.lower() in ['n', 'no']:
+    print('Exiting process.')
+    exit()
+  
+# Restore the index and associated data to the application.
+try:
+    print('Restoring index...')
+    index.replace_all_objects(index_data, {
+        'safe': True
+    })
+    print('Index restored.')
+    
+    if is_settings_file:
+        print('Restoring settings...')
+        index.set_settings(settings_data)
+        print('Settings restored...')
+
+    if is_rules_file:
+        print('Restoring rules...')
+        index.replace_all_rules(rules_data)
+        print('Rules restored...')
+
+    if is_synonyms_file:
+        print('Restoring synonyms...')
+        index.replace_all_synonyms(synonyms_data)
+        print('Synonyms restored...')
+except Exception as e:
+    print(f'Error restoring index data: {e}')
+    exit()

--- a/python/restore.py
+++ b/python/restore.py
@@ -51,19 +51,19 @@ if not is_index_file:
     exit()
 
 # Load the json files so that the data can be restored
-with open(f'{current_path}/{ALGOLIA_INDEX_NAME}_index.json', 'r') as f:
+with open(f'{current_path}/{ALGOLIA_INDEX_NAME}_index.json', 'r', encoding='utf-16') as f:
     index_data = json.load(f)
 
 if is_settings_file:
-    with open(f'{current_path}/{ALGOLIA_INDEX_NAME}_settings.json', 'r') as f:
+    with open(f'{current_path}/{ALGOLIA_INDEX_NAME}_settings.json', 'r', encoding='utf-16') as f:
         settings_data = json.load(f)
 
 if is_rules_file:
-    with open(f'{current_path}/{ALGOLIA_INDEX_NAME}_rules.json', 'r') as f:
+    with open(f'{current_path}/{ALGOLIA_INDEX_NAME}_rules.json', 'r', encoding='utf-16') as f:
         rules_data = json.load(f)
 
 if is_synonyms_file:
-    with open(f'{current_path}/{ALGOLIA_INDEX_NAME}_synonyms.json', 'r') as f:
+    with open(f'{current_path}/{ALGOLIA_INDEX_NAME}_synonyms.json', 'r', encoding='utf-16') as f:
         synonyms_data = json.load(f)
 
 # Check the status of the current index.


### PR DESCRIPTION
Add backup.py and restore.py scripts to the python samples. Allows for backup of an index and associated rules, synonyms and settings and restore of the same.

**Contributing to Algolia Samples**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.