### PR TITLE
Feat/add way to sort by record size

### DIFF
--- a/javascript/backup_index.js
+++ b/javascript/backup_index.js
@@ -75,7 +75,7 @@ let records = [],
 
     console.log(`${synonyms.length} synonyms retrieved`);
   } catch (error) {
-    console.log(`Error retrieving data ${error}`);
+    console.log(`Error retrieving data ${error.message}`);
   }
 
   //   write json files to current directory
@@ -90,7 +90,7 @@ let records = [],
       );
     } else
       (error) => {
-        console.log(`Error writing files: ${error}`);
+        console.log(`Error writing files: ${error.message}`);
       };
   }
   try {
@@ -103,6 +103,6 @@ let records = [],
     name = "synonyms";
     createJson(synonyms, name);
   } catch (error) {
-    console.log(`Error exporting data ${error}`);
+    console.log(`Error exporting data ${error.message}`);
   }
 })();

--- a/javascript/find_largest_records_on_index.js
+++ b/javascript/find_largest_records_on_index.js
@@ -1,0 +1,83 @@
+/*
+Backup Index
+This script will export an index, including records, settings, rules and synonyms to the current directory.
+It can be used in conjunction with restore.js to backup and restore an index to an application.
+*/
+
+// Install the API client: https://www.algolia.com/doc/api-client/getting-started/install/javascript/?client=javascript
+const algoliasearch = require("algoliasearch");
+const dotenv = require("dotenv");
+
+dotenv.config();
+
+// Get your Algolia Application ID and (admin) API key from the dashboard: https://www.algolia.com/account/api-keys
+// and choose a name for your index. Add these environment variables to a `.env` file:
+const ALGOLIA_APP_ID = process.env.ALGOLIA_APP_ID;
+const ALGOLIA_API_KEY = process.env.ALGOLIA_API_KEY;
+const ALGOLIA_INDEX_NAME = process.env.ALGOLIA_INDEX_NAME;
+
+// Start the API client
+// https://www.algolia.com/doc/api-client/getting-started/instantiate-client-index/
+const client = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY);
+
+// Create an index (or connect to it, if an index with the name `ALGOLIA_INDEX_NAME` already exists)
+// https://www.algolia.com/doc/api-client/getting-started/instantiate-client-index/#initialize-an-index
+const index = client.initIndex(ALGOLIA_INDEX_NAME);
+
+// Requiring fs module in which writeFile function is defined.
+const fs = require("fs");
+
+let records = [],
+  settings = [],
+  rules = [],
+  synonyms = [];
+
+(async () => {
+  // retrieve all records from index
+  console.log(`Retrieving records...`);
+  try {
+    await index.browseObjects({
+      batch: (batch) => {
+
+        // This method gets an approximation of the size of the record (total string length) we can use for sorting purposes 
+        for (let i = 0; i < batch.length; i++) {
+            batch[i].string_length = JSON.stringify(batch[i]).length;
+        } 
+        records = records.concat(batch);
+      }
+    });
+
+    console.log(`${records.length} records retrieved`);
+
+    console.log(`Sorting Records By Size...`);
+
+    // Sort the result so the largest string length is at the beggining
+    records.sort((a, b) => b.string_length - a.string_length);
+
+    
+  } catch (error) {
+    console.log(`Error retrieving data ${error}`);
+  }
+
+  //   write json files to current directory
+  function createJson(data, name) {
+    if (data) {
+      fs.writeFile(
+        `${ALGOLIA_INDEX_NAME}_${name}.json`,
+        JSON.stringify(data),
+        (err) => {
+          if (err) throw err;
+        }
+      );
+    } else
+      (error) => {
+        console.log(`Error writing files: ${error}`);
+      };
+  }
+  try {
+    let name = "records";
+    createJson(records, name);
+  } catch (error) {
+    console.log(`Error exporting data ${error}`);
+  }
+})();

--- a/javascript/sort_index_by_record_size.js
+++ b/javascript/sort_index_by_record_size.js
@@ -26,10 +26,7 @@ const index = client.initIndex(ALGOLIA_INDEX_NAME);
 // Requiring fs module in which writeFile function is defined.
 const fs = require("fs");
 
-let records = [],
-  settings = [],
-  rules = [],
-  synonyms = [];
+let records = [];
 
 (async () => {
   // retrieve all records from index
@@ -55,7 +52,7 @@ let records = [],
 
     
   } catch (error) {
-    console.log(`Error retrieving data ${error}`);
+    console.log(`Error retrieving data ${error.message}`);
   }
 
   //   write json files to current directory
@@ -70,13 +67,13 @@ let records = [],
       );
     } else
       (error) => {
-        console.log(`Error writing files: ${error}`);
+        console.log(`Error writing files: ${error.message}`);
       };
   }
   try {
     let name = "records";
     createJson(records, name);
   } catch (error) {
-    console.log(`Error exporting data ${error}`);
+    console.log(`Error exporting data ${error.message}`);
   }
 })();

--- a/javascript/sort_index_by_record_size.js
+++ b/javascript/sort_index_by_record_size.js
@@ -1,7 +1,6 @@
 /*
-Backup Index
-This script will export an index, including records, settings, rules and synonyms to the current directory.
-It can be used in conjunction with restore.js to backup and restore an index to an application.
+Sort Index By Record Size
+Sometimes we want to easily find the largest record in an index (in file size) so we can investigate situations where some small number of records are over the fileSizeLimit. This script is designed to fetch the entire index and then sort it by the total string size, and then export it to a file for analysis.
 */
 
 // Install the API client: https://www.algolia.com/doc/api-client/getting-started/install/javascript/?client=javascript


### PR DESCRIPTION
This script is designed to sort an index by the s=character size of each record. This can be helpful for investigating large records but please note the size will be different from the final size of the record when stored as a file and so is only indicative of relative size

**Contributing to Algolia Samples**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ X] I acknowledge that all my contributions will be made under the project's license.